### PR TITLE
Replace AddParameter with HttpContent

### DIFF
--- a/src/InstaSharp/OAuth.cs
+++ b/src/InstaSharp/OAuth.cs
@@ -56,15 +56,20 @@ namespace InstaSharp
         public Task<OAuthResponse> RequestToken(string code)
         {
             HttpClient client = new HttpClient { BaseAddress = new Uri(config.OAuthUri) };
-            var request = new HttpRequestMessage(HttpMethod.Post, "access_token");
+            var request = new HttpRequestMessage(HttpMethod.Post, new Uri(client.BaseAddress, "access_token"));
+            //HttpClient client = new HttpClient();
+            //var request = new HttpRequestMessage(HttpMethod.Post, "https://api.instagram.com/oauth/access_token");
+            string myParameters = string.Format("client_id={0}&client_secret={1}&grant_type={2}&redirect_uri={3}&code={4}",
+                config.ClientId.UrlEncode(),
+                config.ClientSecret.UrlEncode(), 
+                "authorization_code".UrlEncode(),
+                config.RedirectUri.UrlEncode(), 
+                code.UrlEncode());
 
-            request.AddParameter("client_id", config.ClientId);
-            request.AddParameter("client_secret", config.ClientSecret);
-            request.AddParameter("grant_type", "authorization_code");
-            request.AddParameter("redirect_uri", config.RedirectUri);
-            request.AddParameter("code", code);
+            request.Content = new StringContent(myParameters);
 
             return client.ExecuteAsync<OAuthResponse>(request);
+
         }
     }
 }


### PR DESCRIPTION
Failed to get access token. Following is the fix:

HttpRequestMessage's 2nd param cannot be relative path
The "POST" request created by AddParameter has content-length = 0 according to fiddler. And Instagram returns 400. After switch to using HttpContent to carry the payload ... now it works.
FYI. the other api (e.g. like.post, like.delete) seems to work fine without having to use HttpContent.
