### PR TITLE
Added missing oauth parameter in tags endpoint

### DIFF
--- a/src/InstaSharp/Endpoints/Comments.cs
+++ b/src/InstaSharp/Endpoints/Comments.cs
@@ -11,9 +11,9 @@ namespace InstaSharp.Endpoints {
         /// Comments Endpoints
         /// </summary>
         /// <param name="config">An instance of the InstagramConfig class.</param>
-        /// <param name="authInfo">An instance of the AuthInfo class.</param>
-        public Comments(InstagramConfig config, OAuthResponse authInfo) :
-            base("media/", config, authInfo) { }
+        /// <param name="auth">An instance of the OAuthResponse class.</param>
+        public Comments(InstagramConfig config, OAuthResponse auth) :
+            base("media/", config, auth) { }
 
         /// <summary>
         /// Get a full list of comments on a media.

--- a/src/InstaSharp/Endpoints/Geographies.cs
+++ b/src/InstaSharp/Endpoints/Geographies.cs
@@ -9,7 +9,9 @@ namespace InstaSharp.Endpoints {
         /// Geographies Endpoints
         /// </summary>
         /// <param name="config">An instance of the InstagramConfig class.</param>
-        public Geographies(InstagramConfig config) : base("geographies/", config) {}
+        /// <param name="auth">An instance of the OAuthResponse class.</param>
+        public Geographies(InstagramConfig config, OAuthResponse auth = null)
+            : base("geographies/", config, auth) { }
 
         /// <summary>
         /// Get very recent media from a geography subscription that you created. Note: you can only access Geographies that were explicitly created by your OAuth client. To backfill photos from the location covered by this geography, use the media search endpoint.

--- a/src/InstaSharp/Endpoints/Likes.cs
+++ b/src/InstaSharp/Endpoints/Likes.cs
@@ -10,7 +10,7 @@ namespace InstaSharp.Endpoints {
         /// Likes Endpoints
         /// </summary>
         /// <param name="config">An instance of the InstagramConfig class.</param>
-        /// <param name="auth">An instance of the AuthInfo class.</param>
+        /// <param name="auth">An instance of the OAuthResponse class.</param>
         public Likes(InstagramConfig config, OAuthResponse auth)
             : base("media/", config, auth) { }
 

--- a/src/InstaSharp/Endpoints/Locations.cs
+++ b/src/InstaSharp/Endpoints/Locations.cs
@@ -10,8 +10,9 @@ namespace InstaSharp.Endpoints {
         /// Locations Endpoints
         /// </summary>
         /// <param name="config">An instance of the InstaGram config class</param>
-        /// <param name="auth">Optional: An instance of the AuthInfo class</param>
-        public Locations(InstagramConfig config, OAuthResponse auth = null) : base("locations/", config, auth) { }
+        /// <param name="auth">An instance of the OAuthResponse class.</param>
+        public Locations(InstagramConfig config, OAuthResponse auth = null)
+            : base("locations/", config, auth) { }
 
         /// <summary>
         /// The versions of the Foursquare API

--- a/src/InstaSharp/Endpoints/Media.cs
+++ b/src/InstaSharp/Endpoints/Media.cs
@@ -10,7 +10,7 @@ namespace InstaSharp.Endpoints {
         /// Media Endpoints
         /// </summary>
         /// <param name="config">An instance of the InstagramConfig class.</param>
-        /// <param name="auth">An instance of the AuthInfo class.</param>
+        /// <param name="auth">An instance of the OAuthResponse class.</param>
         public Media(InstagramConfig config, OAuthResponse auth = null)
             : base("media/", config, auth) { }
 

--- a/src/InstaSharp/Endpoints/Relationships.cs
+++ b/src/InstaSharp/Endpoints/Relationships.cs
@@ -21,9 +21,9 @@ namespace InstaSharp.Endpoints {
         /// Relationships Endpoints
         /// </summary>
         /// <param name="config">An instance of the InstagramConfig class.</param>
-        /// <param name="oauthResponse">An instance of the OAuthResponse class.</param>
-        public Relationships(InstagramConfig config, OAuthResponse oauthResponse)
-            : base("users/", config, oauthResponse) { }
+        /// <param name="auth">An instance of the OAuthResponse class.</param>
+        public Relationships(InstagramConfig config, OAuthResponse auth)
+            : base("users/", config, auth) { }
 
         /// <summary>
         /// Get the list of users this user follows.

--- a/src/InstaSharp/Endpoints/Tags.cs
+++ b/src/InstaSharp/Endpoints/Tags.cs
@@ -10,8 +10,9 @@ namespace InstaSharp.Endpoints
         /// Tag Endpoints
         /// </summary>
         /// <param name="config">An instance of the InstagramConfig class</param>
-        public Tags(InstagramConfig config)
-            : base("tags/", config) { }
+        /// <param name="auth">An instance of the OAuthResponse class.</param>
+        public Tags(InstagramConfig config, OAuthResponse auth = null)
+            : base("tags/", config, auth) { }
 
         /// <summary>
         /// Get information about a tag object.

--- a/src/InstaSharp/Endpoints/Users.cs
+++ b/src/InstaSharp/Endpoints/Users.cs
@@ -10,9 +10,9 @@ namespace InstaSharp.Endpoints {
         /// User Endpoints
         /// </summary>
         /// <param name="config">An instance of the InstagramConfiguration class</param>
-        /// <param name="OAuthResponse">An instance of the AuthInfo class</param>
-        public Users(InstagramConfig config, OAuthResponse OAuthResponse = null)
-            : base("users/", config, OAuthResponse) { }
+        /// <param name="auth">An instance of the OAuthResponse class.</param>
+        public Users(InstagramConfig config, OAuthResponse auth = null)
+            : base("users/", config, auth) { }
 
         /// <summary>
         /// Get basic information about a user.


### PR DESCRIPTION
Added missing oauth parameter in tags and Geographies endpoint
Renamed authentication endpoint constructor parameter to auth for all endpoint constructors to make it more consistent.   
